### PR TITLE
Misc cable fixes

### DIFF
--- a/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntityCable.java
+++ b/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntityCable.java
@@ -9,5 +9,7 @@ public interface IMetaTileEntityCable extends IMetaTileEntity {
     @Deprecated
     public long transferElectricity(byte aSide, long aVoltage, long aAmperage, ArrayList<TileEntity> aAlreadyPassedTileEntityList);
 
-    public long transferElectricity(byte aSide, long aVoltage, long aAmperage, HashSet<TileEntity> aAlreadyPassedSet);
+    default public long transferElectricity(byte aSide, long aVoltage, long aAmperage, HashSet<TileEntity> aAlreadyPassedSet) {
+        return transferElectricity(aSide, aVoltage, aAmperage, new ArrayList<>(aAlreadyPassedSet));
+    }
 }

--- a/src/main/java/gregtech/api/interfaces/tileentity/IEnergyConnected.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/IEnergyConnected.java
@@ -32,13 +32,17 @@ public interface IEnergyConnected extends IColoredTileEntity, IHasWorldObjectAnd
      * Sided Energy Input
      */
     public boolean inputEnergyFrom(byte aSide);
-    public boolean inputEnergyFrom(byte aSide, boolean waitForActive);
+    default public boolean inputEnergyFrom(byte aSide, boolean waitForActive) {
+        return inputEnergyFrom(aSide);
+    }
 
     /**
      * Sided Energy Output
      */
     public boolean outputsEnergyTo(byte aSide);
-    public boolean outputsEnergyTo(byte aSide, boolean waitForActive);
+    default public boolean outputsEnergyTo(byte aSide, boolean waitForActive) {
+        return outputsEnergyTo(aSide);
+    }
 
     /**
      * Utility for the Network

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -908,6 +908,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
         return inputEnergyFrom(aSide, true);
     }
 
+    @Override
     public boolean inputEnergyFrom(byte aSide, boolean waitForActive) {
         if (aSide == 6) return true;
         if (isServerSide() && waitForActive) return ((aSide >= 0 && aSide < 6) && mActiveEUInputs[aSide]) && !mReleaseEnergy;

--- a/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
@@ -724,7 +724,7 @@ public abstract class MetaPipeEntity implements IMetaTileEntity, IConnectable {
         if ((alwaysLookConnected || letsIn || letsOut))  {
             // Are we trying to connect to a pipe? let's do it!
             IMetaTileEntity tPipe = tTileEntity instanceof IGregTechTileEntity ? ((IGregTechTileEntity) tTileEntity).getMetaTileEntity() : null;
-            if (getClass().isInstance(tPipe)) {
+            if (getClass().isInstance(tPipe) || (tPipe != null && tPipe.getClass().isInstance(this))) {
                 connectAtSide(aSide);
                 if (!((MetaPipeEntity) tPipe).isConnectedAtSide(tSide)) {
                     // Make sure pipes all get together -- connect back to us if we're connecting to a pipe
@@ -768,7 +768,7 @@ public abstract class MetaPipeEntity implements IMetaTileEntity, IConnectable {
 		byte tSide = GT_Utility.getOppositeSide(aSide);
 		IGregTechTileEntity tTileEntity = getBaseMetaTileEntity().getIGregTechTileEntityAtSide(aSide);
 		IMetaTileEntity tPipe = tTileEntity == null ? null : tTileEntity.getMetaTileEntity();
-		if (this.getClass().isInstance(tPipe) && ((MetaPipeEntity) tPipe).isConnectedAtSide(tSide))
+		if ((this.getClass().isInstance(tPipe) || (tPipe != null && tPipe.getClass().isInstance(this))) && ((MetaPipeEntity) tPipe).isConnectedAtSide(tSide))
 			((MetaPipeEntity) tPipe).disconnect(tSide);
 	}
 

--- a/src/main/java/gregtech/common/GT_Client.java
+++ b/src/main/java/gregtech/common/GT_Client.java
@@ -13,6 +13,7 @@ import gregtech.api.enums.Materials;
 import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.interfaces.tileentity.ITurnable;
 import gregtech.api.metatileentity.BaseMetaPipeEntity;
+import gregtech.api.metatileentity.BaseTileEntity;
 import gregtech.api.objects.GT_FluidStack;
 import gregtech.api.util.GT_Log;
 import gregtech.api.util.GT_PlayedSound;
@@ -326,6 +327,11 @@ public class GT_Client extends GT_Proxy
                     drawGrid(aEvent);
                     return;
                 }
+                if (aTileEntity instanceof BaseTileEntity && (GT_Utility.isStackInList(aEvent.currentItem, GregTech_API.sWireCutterList))) {
+                    drawGrid(aEvent);
+                    return;
+                }
+
             } catch (Throwable e) {
                 if (GT_Values.D1) {
                     e.printStackTrace(GT_Log.err);


### PR DESCRIPTION
* Work with subclassed GT cables (ie: gt++ cables)
* Render grid when wire cutters held Fixes #41
