### PR TITLE
Only allow fluid containers in tanks

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicTank.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicTank.java
@@ -91,6 +91,13 @@ public abstract class GT_MetaTileEntity_BasicTank extends GT_MetaTileEntity_Tier
         return true;
     }
 
+    
+    @Override
+    public boolean isItemValidForSlot(int aIndex, ItemStack aStack) {
+        return getBaseMetaTileEntity().isValidSlot(aIndex) && aStack != null && aStack.getItem() instanceof IFluidContainerItem;
+    }
+
+    
     public FluidStack getFillableStack() {
         return mFluid;
     }

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicTank.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicTank.java
@@ -10,7 +10,7 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.fluids.FluidStack;
-
+import net.minecraftforge.fluids.IFluidContainerItem;
 /**
  * NEVER INCLUDE THIS FILE IN YOUR MOD!!!
  * <p/>


### PR DESCRIPTION
Override isItemValidForSlot so that we only allow fluid containers.