### PR TITLE
Fixup travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ before_deploy:
 - git tag "$TRAVIS_BRANCH-build-$(date +'%Y%m%d%H%M%S')-$(git log --format=%h -1)"
 deploy:
   provider: releases
-  api_key:
-    secure: $API_KEY_QUOTES
+  api_key: $GH_DEPLOY_KEY
   file:
   - build/libs/*.jar
   - README.md


### PR DESCRIPTION
We can't use `secure` and a variable from travis, it hates that
apparently.